### PR TITLE
getContent() deprecated in Flow 5.1

### DIFF
--- a/Classes/Service/GeocodingService.php
+++ b/Classes/Service/GeocodingService.php
@@ -48,7 +48,7 @@ class GeocodingService
         $browser = new Browser();
         $browser->setRequestEngine(new CurlEngine());
         $response = $browser->request($url);
-        $jsonContent = $response->getContent();
+        $jsonContent = $response->getBody();
 
         if ($jsonContent) {
             $json = json_decode($jsonContent, true);


### PR DESCRIPTION
Sali Stefan,
Die Anpassung der folgenden Zeile sollte dein Paket mit Neos v5 kompatibel machen.
https://neos.github.io/flow/master/source-class-Neos.Flow.Http.Response.html#118-128
Lieber Gruss